### PR TITLE
Issue 147

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -57,7 +57,7 @@ jobs:
 
   build-macos:
 
-    runs-on: [ macos-11 ]
+    runs-on: [ macos-latest ]
 
     steps:
     - uses: actions/checkout@master

--- a/src/call_consensus_pileup.cpp
+++ b/src/call_consensus_pileup.cpp
@@ -33,8 +33,9 @@ ret_t get_consensus_allele(std::vector<allele> ad, uint8_t min_qual,
   std::vector<allele> nuc_pos;
   allele tmp_a;
   char n;
-  uint32_t max_l = 0, max_depth = 0, cur_depth = 0, tmp_depth = 0,
+  uint32_t max_l = 0, max_depth = 0, tmp_depth = 0,
            total_max_depth = 0, gap_depth = 0, total_indel_depth = 0;
+  // uint32_t cur_depth = 0;
   uint8_t ambg_n = 1, ctr = 0;
   double q = 0, tq = 0, cur_threshold = 0;
   std::vector<allele>::iterator it;
@@ -56,7 +57,7 @@ ret_t get_consensus_allele(std::vector<allele> ad, uint8_t min_qual,
     tq = 0;
     max_depth = 0;
     tmp_depth = 0;
-    cur_depth = 0;
+    // cur_depth = 0;
     // prev_depth = 0;
     ctr = 1;
     it = ad.begin();
@@ -84,7 +85,7 @@ ret_t get_consensus_allele(std::vector<allele> ad, uint8_t min_qual,
         it++;
         ctr++;
       }
-      cur_depth += tmp_depth;
+      // cur_depth += tmp_depth;
       tmp_a.nuc = it->nuc[i];
       tmp_a.mean_qual = tq;
       tmp_a.reverse = 0;  // Reverse reads not important for consensus

--- a/src/ivar.cpp
+++ b/src/ivar.cpp
@@ -17,7 +17,7 @@
 #include "suffix_tree.h"
 #include "trim_primer_quality.h"
 
-const std::string VERSION = "1.3.1";
+const std::string VERSION = "1.3.2";
 
 struct args_t {
   std::string bam;               // -i

--- a/src/primer_bed.cpp
+++ b/src/primer_bed.cpp
@@ -300,23 +300,6 @@ primer get_max_end(std::vector<primer> primers) {
   return *(minmax_start.second);
 }
 
-// give a primer index, find its pair and return the primer
-primer fetch_primer_pair(int16_t index, std::vector<primer> primers) {
-  /*
-   * @param index: the pair index for the primer of interest
-   * @return pair_primer: the primer object that's pairs with the primer of
-   * interest
-   */
-  std::vector<primer>::iterator it;
-  primer pair_primer;
-  for (it = primers.begin(); it != primers.end(); ++it) {
-    if (it->get_indice() == index) {
-      return *it;
-    }
-  }
-  return (pair_primer);
-}
-
 void print_all_primer_info(std::vector<primer> primers) {
   std::vector<primer>::iterator it;
   for (it = primers.begin(); it != primers.end(); ++it) {

--- a/src/primer_bed.h
+++ b/src/primer_bed.h
@@ -49,7 +49,6 @@ std::vector<primer> populate_from_file(std::string path, int32_t offset);
 std::vector<primer> populate_from_file(std::string path);
 std::vector<primer> get_primers(std::vector<primer> p, unsigned int pos);
 int get_primer_indice(std::vector<primer> p, std::string name);
-primer fetch_primer_pair(int16_t index, std::vector<primer> primers);
 int populate_pair_indices(std::vector<primer>& primers, std::string path);
 void print_primer_info(primer primers);
 void print_all_primer_info(std::vector<primer> primers);

--- a/src/primer_bed.h
+++ b/src/primer_bed.h
@@ -13,11 +13,11 @@ class primer {
   uint32_t start;  // 0 based
   uint32_t end;    // 0 based
   std::string name;
-  int score;
+  int score = 0;
   char strand;
   int16_t pair_indice;
   int16_t indice;
-  uint32_t read_count;
+  uint32_t read_count = 0;
 
  public:
   std::string get_name();

--- a/src/trim_primer_quality.cpp
+++ b/src/trim_primer_quality.cpp
@@ -386,10 +386,10 @@ void get_overlapping_primers(bam1_t *r, std::vector<primer> primers,
   }
 
   // sort it first
-  std::vector<primer> test = insertionSort(primers, primers.size());
+  //std::vector<primer> test = insertionSort(primers, primers.size());
   // std::cout << test.size() << "\n";
   // then we iterate and push what fits
-  for (std::vector<primer>::iterator it = test.begin(); it != test.end();
+  for (std::vector<primer>::iterator it = primers.begin(); it != primers.end();
        ++it) {
     // if we've passed the end, we're going to find no more matches
     if (start_pos < it->get_start()) {
@@ -596,14 +596,12 @@ int trim_bam_qual_primer(std::string bam, std::string bed, std::string bam_out,
   std::vector<primer> overlapping_primers;
   std::vector<primer>::iterator cit;
   bool primer_trimmed = false;
-  std::string test = "NB552570:188:HL75JAFX3:2:21105:7297:5549";
-
+  std::vector<primer> sorted_primers = insertionSort(primers, primers.size());
   // Iterate through reads
   while (sam_itr_next(in, iter, aln) >= 0) {
     unmapped_flag = false;
     primer_trimmed = false;
-
-    get_overlapping_primers(aln, primers, overlapping_primers);
+    get_overlapping_primers(aln, sorted_primers, overlapping_primers);
 
     if ((aln->core.flag & BAM_FUNMAP) == 0) {  // If mapped
       // if primer pair info provided, check if read correctly overlaps with
@@ -629,7 +627,7 @@ int trim_bam_qual_primer(std::string bam, std::string bed, std::string bam_out,
           (abs(aln->core.isize) - max_primer_len) > abs(aln->core.l_qseq);
       // if reverse strand
       if ((aln->core.flag & BAM_FPAIRED) != 0 && isize_flag) {  // If paired
-        get_overlapping_primers(aln, primers, overlapping_primers);
+        get_overlapping_primers(aln, sorted_primers, overlapping_primers);
         if (overlapping_primers.size() >
             0) {  // If read starts before overlapping regions (?)
           primer_trimmed = true;

--- a/src/trim_primer_quality.h
+++ b/src/trim_primer_quality.h
@@ -64,5 +64,5 @@ void get_overlapping_primers(bam1_t *r, std::vector<primer> primers,
                              bool unpaired_rev);
 int get_bigger_primer(std::vector<primer> primers);
 bool amplicon_filter(IntervalTree amplicons, bam1_t *r);
-
+std::vector<primer> insertionSort(std::vector<primer> primers, uint32_t n);
 #endif

--- a/tests/test_primer_trim.cpp
+++ b/tests/test_primer_trim.cpp
@@ -70,6 +70,7 @@ int main() {
   unsigned int overlapping_primer_sizes[] = {0, 2, 2, 0, 0, 0, 0, 2, 2, 1};
   int ctr = 0;
   std::vector<primer> overlapping_primers;
+  std::vector<primer> sorted_primers = insertionSort(primers, primers.size());     
   primer cand_primer;
   bool isize_flag = false;
   while (sam_itr_next(in, iter, aln) >= 0) {
@@ -79,7 +80,7 @@ int main() {
     isize_flag =
         (abs(aln->core.isize) - max_primer_len) > abs(aln->core.l_qseq);
     std::cout << bam_get_qname(aln) << std::endl;
-    get_overlapping_primers(aln, primers, overlapping_primers);
+    get_overlapping_primers(aln, sorted_primers, overlapping_primers);
     if (overlapping_primers.size() != overlapping_primer_sizes[ctr]) {
       success = -1;
       std::cout << "Overlapping primer sizes for " << bam_get_qname(aln)
@@ -163,6 +164,5 @@ int main() {
   sam_hdr_destroy(header);
   hts_idx_destroy(idx);
   hts_close(in);
-
   return success;
 }


### PR DESCRIPTION
meant to address issue #147 for milestone 1.3.3. currently insertionSort is called many times, leading to a large slowdown in ivar trim. this fix changes the codebase to only call insertionSort one time and updates tests to reflect placement of call outside of get_overlapping_primers.